### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/python-exercises/game_5.py
+++ b/python-exercises/game_5.py
@@ -1,13 +1,20 @@
+from __future__ import print_function
 import random
+
+try:
+    input = raw_input  # Python 2
+except NameError:
+    pass               # Python 3
+
 min = 1
 max = 6
 
 roll_again = "yes"
 
-while roll_again == "yes" or roll_again == "y":
-    print "Rolling the dices..."
-    print "The values are...."
-    print random.randint(min, max)
-    print random.randint(min, max)
+while roll_again in ("yes", "y"):
+    print("Rolling the dices...")
+    print("The values are....")
+    print(random.randint(min, max))
+    print(random.randint(min, max))
 
-    roll_again = raw_input("Roll the dices again?")
+    roll_again = input("Roll the dices again?").strip().lower()


### PR DESCRIPTION
Modify  python-exercises/game_5.py to work in both Python and legacy Python.

Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Also deal gracefully with leading and/or trailing whitespace and capital letters in user input.